### PR TITLE
GLM-6475 - Security > Add gemlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+PATH
+  remote: .
+  specs:
+    ontraport_api (0.3.1)
+      httparty (~> 0.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    mini_mime (1.1.2)
+    minitest (5.18.1)
+    multi_xml (0.6.0)
+    rake (10.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  minitest (~> 5.6)
+  ontraport_api!
+  rake (~> 10.0)
+
+BUNDLED WITH
+   2.1.4

--- a/ontraport_api.gemspec
+++ b/ontraport_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency "minitest", '~> 5.6'
 


### PR DESCRIPTION
Dependabot wants us to bump Bundler and add a Gemlock file. This patch does that. Details:
https://github.com/Crowd9/ontraport_api/security/dependabot/6