### PR TITLE
Update HTTParty gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    httparty (0.21.0)
+    bigdecimal (4.0.1)
+    csv (3.3.5)
+    httparty (0.24.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     minitest (5.18.1)
-    multi_xml (0.6.0)
+    multi_xml (0.8.0)
+      bigdecimal (>= 3.1, < 5)
     rake (12.3.3)
 
 PLATFORMS


### PR DESCRIPTION
[GLM-14063](https://linear.app/gleamio/issue/GLM-14063)

Because of https://github.com/Crowd9/ontraport_api/security/dependabot/9

The update to all the other gems were a necessary step to update the HTTParty gem